### PR TITLE
Change node to nodes for network2.x compatibility

### DIFF
--- a/examples/symbolic.py
+++ b/examples/symbolic.py
@@ -27,7 +27,7 @@ def semi_symbolic():
     g.owner = 'sys'
     g.vars = dict(x='bool')
     g.env_vars.add('x')
-    g.add_path(range(11))
+    nx.add_path(g, range(11))
     g.add_edge(10, 10)
     g.add_edge(10, 0, formula="x")
     # symbolic

--- a/omega/games/enumeration.py
+++ b/omega/games/enumeration.py
@@ -59,7 +59,7 @@ def action_to_steps(aut, qinit='\A \A'):
     # search
     while queue:
         node = queue.pop()
-        values = g.node[node]
+        values = g.nodes[node]
         log.debug('at node: {d}'.format(d=values))
         assert set(values) == varnames, (values, aut.vars)
         u = aut.action['env']

--- a/omega/steps.py
+++ b/omega/steps.py
@@ -170,12 +170,12 @@ class EnumStrategyStepper(object):
 
     def step(self, state):
         """Return next values for variables this component controls."""
-        u = next(u for u in self.graph if self.graph.node[u] == state)
+        u = next(u for u in self.graph if self.graph.nodes[u] == state)
         return self._pick_sys(self.graph.successors(u))
 
     def _pick_sys(self, nodes):
         u = next(iter(nodes))
-        d = self.graph.node[u]
+        d = self.graph.nodes[u]
         # TODO: consider defining `varlist` instead of
         # `inputs` and `outputs`
         return slice_dict(d, self.graph.outputs)

--- a/tests/fixpoint_test.py
+++ b/tests/fixpoint_test.py
@@ -1,6 +1,8 @@
 """Test `omega.symbolic.fixpoint`."""
 import logging
 
+import networkx as nx
+
 logging.getLogger('omega').setLevel(logging.WARNING)
 
 from omega.automata import TransitionSystem
@@ -14,7 +16,7 @@ def test_attractor():
     g = TransitionSystem()
     g.vars['x'] = 'bool'
     g.env_vars.add('x')
-    g.add_path([0, 1, 2, 3])
+    nx.add_path(g, [0, 1, 2, 3])
     g.add_edge(4, 1, formula='x')
     aut = logicizer.graph_to_logic(g, 'loc', True)
     aut.plus_one = True
@@ -40,7 +42,7 @@ def test_attractor():
 
 def test_descendants():
     g = TransitionSystem()
-    g.add_path([0, 1, 2])
+    nx.add_path(g, [0, 1, 2])
     aut = logicizer.graph_to_logic(g, 'pc', True)
     source = aut.add_expr('pc = 0')
     constrain = aut.true
@@ -50,7 +52,7 @@ def test_descendants():
 
 def test_ee_image_only_sys():
     g = TransitionSystem()
-    g.add_path([0, 1, 2])
+    nx.add_path(g, [0, 1, 2])
     aut = logicizer.graph_to_logic(g, 'pc', True)
     u = aut.add_expr('pc = 0')
     v = fx.ee_image(u, aut)

--- a/tests/games_enumeration_test.py
+++ b/tests/games_enumeration_test.py
@@ -78,7 +78,7 @@ def test_forall_init():
     assert len(queue) == 1, queue
     (q,) = queue
     assert q in g, (q, g)
-    d = g.node[q]
+    d = g.nodes[q]
     d_ = dict(x=4, y=False, z=True)
     assert d == d_, d
     # multiple initial states: should pick all
@@ -95,7 +95,7 @@ def test_forall_init():
     varnames = {'x', 'y', 'z'}
     for q in queue:
         assert q in g, (q, g)
-        d = g.node[q]
+        d = g.nodes[q]
         assert set(d) == varnames, d
         assert d['x'] < 5, d
         assert isinstance(d['y'], bool), d
@@ -119,7 +119,7 @@ def test_exist_init():
     assert len(queue) == 1, queue
     (q,) = queue
     assert q in g, (q, g)
-    d = g.node[q]
+    d = g.nodes[q]
     d_ = dict(x=1, y=True, z=True)
     assert d == d_, d
     # multiple initial states: should pick one
@@ -133,7 +133,7 @@ def test_exist_init():
     assert len(queue) == 1, queue
     (q,) = queue
     assert q in g, (q, g)
-    d = g.node[q]
+    d = g.nodes[q]
     varnames = {'x', 'y', 'z'}
     assert set(d) == varnames, d
     assert d['x'] == 1, d
@@ -158,7 +158,7 @@ def test_forall_exist_init():
     assert len(queue) == 1, queue
     (q,) = queue
     assert q in g, (q, g)
-    d = g.node[q]
+    d = g.nodes[q]
     d_ = dict(x=True, y=True)
     assert d ==d_, (d, d_)
     # multiple initial states
@@ -173,8 +173,8 @@ def test_forall_exist_init():
     q0, q1 = queue
     assert q0 in g, (q0, g)
     assert q1 in g, (q1, g)
-    d0 = g.node[q0]
-    d1 = g.node[q1]
+    d0 = g.nodes[q0]
+    d1 = g.nodes[q1]
     varnames = set(keys)
     assert set(d0) == varnames, (d0, varnames)
     assert set(d1) == varnames, (d1, varnames)
@@ -204,7 +204,7 @@ def test_exist_forall_init():
     assert len(queue) == 1, queue
     (q,) = queue
     assert q in g, (q, g)
-    d = g.node[q]
+    d = g.nodes[q]
     d_ = dict(x=True, y=False)
     assert d == d_, (d, d_)
     # multiple initial states
@@ -219,8 +219,8 @@ def test_exist_forall_init():
     q0, q1 = queue
     assert q0 in g, (q0, g)
     assert q1 in g, (q1, g)
-    d0 = g.node[q0]
-    d1 = g.node[q1]
+    d0 = g.nodes[q0]
+    d1 = g.nodes[q1]
     varnames = set(keys)
     assert set(d0) == varnames, (d0, varnames)
     assert set(d1) == varnames, (d1, varnames)
@@ -252,7 +252,7 @@ def test_add_new_node():
     assert u == 0, u
     assert len(g) == 1, g
     assert u in g, (u, g.nodes())
-    du = g.node[u]
+    du = g.nodes[u]
     assert du == d, du
     values = (False, 99)
     assert values in umap, (values, umap)


### PR DESCRIPTION
A minor change to games/enumeration.py to change node to nodes. This should be compatible with both NetworkX1.x and NetworkX2.x according to

https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html